### PR TITLE
Add webmail with DNS

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -23,15 +23,15 @@ REPORT_STATS=yes
 
 IDENTITY_SERVER_URL=https://vector.im
 
-SMTP_HOST=host.docker.internal
+SMTP_HOST=mail.$DOMAIN
 SMTP_PORT=1025
 MAIL_NOTIF_FROM_ADDRESS=noreply@$DOMAIN
 ABUSE_SUPPORT_EMAIL=abuse@$DOMAIN
 SECURITY_SUPPORT_EMAIL=security@$DOMAIN
 
 MAS_CLIENT_ID="0000000000000000000SYNAPSE"
-MAS_EMAIL_FROM=Matrix Authentication Service <support@${DOMAIN}>
-MAS_EMAIL_REPLY_TO=Matrix Authentication Service <support@${DOMAIN}>
+MAS_EMAIL_FROM="Matrix Authentication Service <support@$DOMAIN>"
+MAS_EMAIL_REPLY_TO="Matrix Authentication Service <support@$DOMAIN>"
 
 # This should be the public IP of your $LIVEKIT_FQDN.
 # If livekit doesn't work, double-check this.
@@ -40,7 +40,7 @@ LIVEKIT_NODE_IP=127.0.0.1
 COUNTRY=FR
 
 # as a convenience for creating /etc/hosts
-DOMAINS="$DOMAIN $HOMESERVER_FQDN $MAS_FQDN $ELEMENT_WEB_FQDN $ELEMENT_CALL_FQDN $LIVEKIT_FQDN $LIVEKIT_JWT_FQDN $SSO_FQDN"
+DOMAINS="$DOMAIN $HOMESERVER_FQDN $MAS_FQDN $ELEMENT_WEB_FQDN $ELEMENT_CALL_FQDN $LIVEKIT_FQDN $LIVEKIT_JWT_FQDN $SSO_FQDN $SMTP_HOST"
 
 # Variables pour les services additionnels
 # TODO : move those options to another .env

--- a/compose-tchap-additional-services.yml
+++ b/compose-tchap-additional-services.yml
@@ -102,5 +102,6 @@ services:
         condition: service_completed_successfully
     extra_hosts:
       - "sso.tchapgouv.com:host-gateway"
+      - "mail.tchapgouv.com:host-gateway"
     profiles:
       [with_mas]

--- a/compose.yml
+++ b/compose.yml
@@ -34,7 +34,8 @@ services:
 
   generate-mas-secrets:
     restart: "no"
-    image: ghcr.io/element-hq/matrix-authentication-service:latest
+    #:tchap:
+    image: ghcr.io/tchapgouv/matrix-authentication-service:release-tchap_202509_RC7
     user: $USER_ID:$GROUP_ID
     volumes:
       - ${VOLUME_PATH}/data/mas:/data:rw

--- a/data-template/nginx/conf.d/app.conf
+++ b/data-template/nginx/conf.d/app.conf
@@ -108,6 +108,20 @@ server {
     }
 }
 
+#mailhog
+server {
+    server_name ${SMTP_HOST};
+    server_tokens off;
+
+    include /etc/nginx/conf.d/include/ssl.conf;
+
+    location / {
+        proxy_pass http://mailhog:8025;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For ${DOLLAR}remote_addr;
+    }
+}
+
 # server {
 #     server_name ${LIVEKIT_FQDN};
 #     server_tokens off;

--- a/tchap/README_TCHAP.md
+++ b/tchap/README_TCHAP.md
@@ -14,7 +14,8 @@ Then:
 ```
 ./setup.sh
 
-# Type your domain ie. : `tchapgouv.com`
+# NOTE: it is important to use tchapgouv.com as a domain / our sydent mock is configure with this
+# Type your domain : `tchapgouv.com`
 
 # Point DNS for *.domain at your docker host,
 # Or if running on localhost with mkcert:
@@ -40,4 +41,4 @@ For instance for mas, you need to use the configuration file `data/mas/config.ya
 
 ## Mailhog
 
-you can access mailhog at this url : https://localhost:8025
+you can access mailhog at this url : https://mail.tchapgouv.com:8025

--- a/tchap/nginx/.app.local.dev.conf
+++ b/tchap/nginx/.app.local.dev.conf
@@ -108,6 +108,21 @@ server {
     }
 }
 
+#mailhog
+server {
+    server_name ${SMTP_HOST};
+    server_tokens off;
+
+    include /etc/nginx/conf.d/include/ssl.conf;
+
+    location / {
+        proxy_pass http://mailhog:8025;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For ${DOLLAR}remote_addr;
+    }
+}
+
+
 server {
     server_name ${LIVEKIT_FQDN};
     server_tokens off;

--- a/tchap/nginx/.app.local.dev.light.conf
+++ b/tchap/nginx/.app.local.dev.light.conf
@@ -108,6 +108,20 @@ server {
     }
 }
 
+#mailhog
+server {
+    server_name ${SMTP_HOST};
+    server_tokens off;
+
+    include /etc/nginx/conf.d/include/ssl.conf;
+
+    location / {
+        proxy_pass http://mailhog:8025;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For ${DOLLAR}remote_addr;
+    }
+}
+
 # server {
 #     server_name ${LIVEKIT_FQDN};
 #     server_tokens off;


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-docker-integration/issues/3

- Add DNS for mailhog (this could be used when running a local mas)
- correct variable syntax in .env.sample
- use mas tchap fork image to generate secrets (can prevent any change from upstream image)
- update README : domain `tchapgouv.com` should be used in order to work as sydent is configured with this domain at this stage