### PR TITLE
move profiles to .env and update doc

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -48,3 +48,7 @@ IDENTITY_MOCK_PORT=8083
 KEYCLOAK_PORT=8082
 KEYCLOAK_HOSTNAME=https://sso.tchapgouv.com
 POSTGRES_PORT=5434
+
+#choose which services to start with docker compose profiles
+#availables : [element, tchap, with_mas, with_web, full]
+COMPOSE_PROFILES="tchap,with_mas,with_web"

--- a/compose-tchap-additional-services.yml
+++ b/compose-tchap-additional-services.yml
@@ -65,7 +65,7 @@ services:
       [tchap]
 
   tchap-web:
-    image: develop_tchap:latest
+    image: ghcr.io/tchapgouv/tchap-web-v4:latest
     restart: unless-stopped
     # ports:
     #   - 8080:80
@@ -82,7 +82,7 @@ services:
       init:
         condition: service_completed_successfully
     profiles:
-      [tchap, with_web]
+      [with_web]
 
   mas-tchap:
     image: ghcr.io/tchapgouv/matrix-authentication-service:release-tchap_202509_RC7

--- a/start_tchap.sh
+++ b/start_tchap.sh
@@ -9,8 +9,5 @@ cp tchap/synapse/homeserver.local.dev.light.yaml data-template/synapse/homeserve
 cp tchap/mas/config.local.dev.yaml data-template/mas/config.yaml
 cp tchap/tchap-web/config.local.json data-template/tchap-web/config.local.json
 
-#export COMPOSE_PROFILES="tchap,with_mas,with_web"
-export COMPOSE_PROFILES="tchap,with_web"
-# Lancer les deux fichiers compose ensemble
-#docker compose -f compose.yml -f compose-tchap-additional-services.yml up -d
+# start docker compose with main services and tchap services
 docker compose -f compose.yml -f compose-tchap-additional-services.yml up -d

--- a/tchap/README_TCHAP.md
+++ b/tchap/README_TCHAP.md
@@ -44,7 +44,7 @@ From tchap :
  * Tchap Web
  * Identity server (mock)
  * Tchap MAS
-
+ * Keycloak for OIDC upstream login
 
 With `.env` variable `COMPOSE_PROFILES` you can select which services to run. 
 

--- a/tchap/README_TCHAP.md
+++ b/tchap/README_TCHAP.md
@@ -27,6 +27,46 @@ Then:
 
 if containers do not start, start them manually
 
+## Start custom services
+
+This integration environment starts multiple services from the Element and Tchap environment
+
+From Element environment : 
+ * Element Web
+ * Element Call
+ * Synapse
+ * Matrix Authentication Service
+ * LiveKit
+ * Postgres
+ * nginx + letsencrypt / mkcert for TLS.
+
+From tchap : 
+ * Tchap Web
+ * Identity server (mock)
+ * Tchap MAS
+
+
+With `.env` variable `COMPOSE_PROFILES` you can select which services to run. 
+
+By default the following services start with `COMPOSE_PROFILES="tchap,with_mas,with_web"` 
+ * Synapse
+ * Postgres
+ * nginx + letsencrypt / mkcert for TLS.
+ * Tchap Web
+ * Identity server (mock)
+ * Tchap MAS
+ * Keycloak for OIDC upstream login
+
+By using profiles `element` those services will start also : 
+ * Element Call
+ * Element Web
+ * Synapse
+ * LiveKit
+
+Note : Tchap MAS and Element MAS will conflict on port bindings
+
+If you specify `full`, additional workers for Synapse will start (TODO : also need tweak in synapse conf    )
+
 ## Local dev
 
 If you want to start your own MAS, change the variable in the start_tchap.sh to remove the `with_mas` value. 


### PR DESCRIPTION
## Start custom services

This integration environment starts multiple services from the Element and Tchap environment

From Element environment : 
 * Element Web
 * Element Call
 * Synapse
 * Matrix Authentication Service
 * LiveKit
 * Postgres
 * nginx + letsencrypt / mkcert for TLS.

From tchap : 
 * Tchap Web
 * Identity server (mock)
 * Tchap MAS
 * Keycloak for OIDC upstream login

With `.env` variable `COMPOSE_PROFILES` you can select which services to run. 

By default the following services start with `COMPOSE_PROFILES="tchap,with_mas,with_web"` 
 * Synapse
 * Postgres
 * nginx + letsencrypt / mkcert for TLS.
 * Tchap Web
 * Identity server (mock)
 * Tchap MAS
 * Keycloak for OIDC upstream login

By using profiles `element` those services will start also : 
 * Element Call
 * Element Web
 * Synapse
 * LiveKit

Note : Tchap MAS and Element MAS will conflict on port bindings

If you specify `full`, additional workers for Synapse will start (TODO : also need tweak in synapse conf    )