### PR TITLE
Fix components version

### DIFF
--- a/compose-tchap-additional-services.yml
+++ b/compose-tchap-additional-services.yml
@@ -5,7 +5,7 @@ networks:
 
 services:
   postgres-keycloak:
-    image: postgres
+    image: postgres:15
     ports:
       - "${POSTGRES_PORT:-5434}:5432"
     environment:
@@ -65,7 +65,7 @@ services:
       [tchap]
 
   tchap-web:
-    image: ghcr.io/tchapgouv/tchap-web-v4:latest
+    image: ghcr.io/tchapgouv/tchap-web-v4:develop_tchap
     restart: unless-stopped
     ports:
       - 8088:80

--- a/compose.yml
+++ b/compose.yml
@@ -110,10 +110,10 @@ services:
                  done;'"
 
   postgres:
-    image: postgres:latest
+    image: postgres:15 #tchap uses postgres 15
     restart: unless-stopped
     volumes:
-      - ${VOLUME_PATH}/data/postgres:/var/lib/postgresql/data:rw
+      - ${VOLUME_PATH}/data/postgres:/var/lib/postgresql:rw
       - ${VOLUME_PATH}/scripts/create-multiple-postgresql-databases.sh:/docker-entrypoint-initdb.d/create-multiple-postgresql-databases.sh
     networks:
       - backend
@@ -170,7 +170,7 @@ services:
         condition: service_completed_successfully
 
   synapse-generic-worker-1:
-    image: ghcr.io/element-hq/synapse:latest
+    image: ghcr.io/element-hq/synapse:1.136
     user: $USER_ID:$GROUP_ID
     restart: unless-stopped
     entrypoint: ["/start.py", "run", "--config-path=/data/homeserver.yaml", "--config-path=/data/workers/synapse-generic-worker-1.yaml"]
@@ -199,7 +199,7 @@ services:
       [with_workers]
 
   synapse-federation-sender-1:
-    image: ghcr.io/element-hq/synapse:latest
+    image: ghcr.io/element-hq/synapse:1.136
     user: $USER_ID:$GROUP_ID
     restart: unless-stopped
     entrypoint: ["/start.py", "run", "--config-path=/data/homeserver.yaml", "--config-path=/data/workers/synapse-federation-sender-1.yaml"]

--- a/compose.yml
+++ b/compose.yml
@@ -146,7 +146,7 @@ services:
       - backend
 
   synapse:
-    image: ghcr.io/element-hq/synapse:latest
+    image: ghcr.io/element-hq/synapse:1.136
     user: $USER_ID:$GROUP_ID
     restart: unless-stopped
     volumes:

--- a/data-template/mas/config.yaml
+++ b/data-template/mas/config.yaml
@@ -262,5 +262,5 @@ rate_limiting:
   # based on source IP address.
   # This limit can protect against e-mail spam and against people registering too many accounts.
   registration:
-    burst: 500
+    burst: 500 #:tchap: needed for automatic testing
     per_second: 0.0008

--- a/data-template/mas/config.yaml
+++ b/data-template/mas/config.yaml
@@ -246,7 +246,7 @@ rate_limiting:
     # based on source IP address.
     # This can protect against brute force login attempts.
     per_ip:
-      burst: 3
+      burst: 200
       per_second: 0.05
 
     # Controls how many login attempts are permitted

--- a/data-template/mas/config.yaml
+++ b/data-template/mas/config.yaml
@@ -187,6 +187,28 @@ telemetry:
   #   # DSN to use for sending errors and crashes to Sentry
   #   dsn: https://public@host:port/1
 
+experimental:
+  # Time-to-live of OAuth 2.0 access tokens in seconds. Defaults to 300, 5 minutes.
+  access_token_ttl: 30
+
+  # Time-to-live of compatibility access tokens in seconds, when refresh tokens are supported. Defaults to 300, 5 minutes.
+  #compat_token_ttl: 300
+
+  # Experimental feature to automatically expire inactive sessions
+  # Disabled by default
+  #inactive_session_expiration:
+     # Time after which an inactive session is automatically finished in seconds
+     #ttl: 32400
+
+     # Should compatibility sessions expire after inactivity. Defaults to true.
+     #expire_compat_sessions: true
+
+     # Should OAuth 2.0 sessions expire after inactivity. Defaults to true.
+     #expire_oauth_sessions: true
+
+     # Should user sessions expire after inactivity. Defaults to true.
+     #expire_user_sessions: true
+
 tchap:
   identity_server_url: "http://host.docker.internal:8083"
   email_lookup_fallback_rules: 
@@ -195,3 +217,50 @@ tchap:
   # old email in mail.numerique.gouv.fr
   - match_with : '@numerique.gouv.fr'
     search: '@beta.gouv.fr'
+
+
+rate_limiting:
+ # Limits how many account recovery attempts are allowed.
+  # These limits can protect against e-mail spam.
+  #
+  # Note: these limit also apply to recovery e-mail re-sends.
+  account_recovery:
+    # Controls how many account recovery attempts are permitted
+    # based on source IP address.
+    per_ip:
+      burst: 3
+      per_second: 0.0008
+
+    # Controls how many account recovery attempts are permitted
+    # based on the e-mail address that is being used for recovery.
+    per_address:
+      burst: 3
+      per_second: 0.0002
+
+  # Limits how many login attempts are allowed.
+  #
+  # Note: these limit also applies to password checks when a user attempts to
+  # change their own password.
+  login:
+    # Controls how many login attempts are permitted
+    # based on source IP address.
+    # This can protect against brute force login attempts.
+    per_ip:
+      burst: 3
+      per_second: 0.05
+
+    # Controls how many login attempts are permitted
+    # based on the account that is being attempted to be logged into.
+    # This can protect against a distributed brute force attack
+    # but should be set high enough to prevent someone's account being
+    # casually locked out.
+    per_account:
+      burst: 1800
+      per_second: 0.5
+
+  # Limits how many registrations attempts are allowed,
+  # based on source IP address.
+  # This limit can protect against e-mail spam and against people registering too many accounts.
+  registration:
+    burst: 500
+    per_second: 0.0008

--- a/data-template/mas/config.yaml
+++ b/data-template/mas/config.yaml
@@ -246,7 +246,7 @@ rate_limiting:
     # based on source IP address.
     # This can protect against brute force login attempts.
     per_ip:
-      burst: 200
+      burst: 200 #:tchap: needed for automatic testing
       per_second: 0.05
 
     # Controls how many login attempts are permitted

--- a/start_tchap.sh
+++ b/start_tchap.sh
@@ -10,8 +10,8 @@ cp tchap/synapse/homeserver.local.dev.light.yaml data-template/synapse/homeserve
 cp tchap/mas/config.local.dev.yaml data-template/mas/config.yaml
 cp tchap/tchap-web/config.local.json data-template/tchap-web/config.local.json
 
-# pull latest version of images
-docker compose pull
+# pull latest version of images of tchap-web and mas-tchap
+docker compose -f compose.yml -f compose-tchap-additional-services.yml pull tchap-web mas-tchap
 
 # start docker compose with main services and tchap services
 docker compose -f compose.yml -f compose-tchap-additional-services.yml up -d

--- a/start_tchap.sh
+++ b/start_tchap.sh
@@ -10,5 +10,8 @@ cp tchap/synapse/homeserver.local.dev.light.yaml data-template/synapse/homeserve
 cp tchap/mas/config.local.dev.yaml data-template/mas/config.yaml
 cp tchap/tchap-web/config.local.json data-template/tchap-web/config.local.json
 
+# pull latest version of images
+docker compose pull
+
 # start docker compose with main services and tchap services
 docker compose -f compose.yml -f compose-tchap-additional-services.yml up -d

--- a/tchap/mas/config.local.dev.yaml
+++ b/tchap/mas/config.local.dev.yaml
@@ -246,7 +246,7 @@ rate_limiting:
     # based on source IP address.
     # This can protect against brute force login attempts.
     per_ip:
-      burst: 300
+      burst: 200
       per_second: 0.05
 
     # Controls how many login attempts are permitted

--- a/tchap/mas/config.local.dev.yaml
+++ b/tchap/mas/config.local.dev.yaml
@@ -246,7 +246,7 @@ rate_limiting:
     # based on source IP address.
     # This can protect against brute force login attempts.
     per_ip:
-      burst: 3
+      burst: 300
       per_second: 0.05
 
     # Controls how many login attempts are permitted

--- a/tchap/mas/config.local.dev.yaml
+++ b/tchap/mas/config.local.dev.yaml
@@ -246,7 +246,7 @@ rate_limiting:
     # based on source IP address.
     # This can protect against brute force login attempts.
     per_ip:
-      burst: 200
+      burst: 200 #:tchap: needed for automatic testing
       per_second: 0.05
 
     # Controls how many login attempts are permitted


### PR DESCRIPTION
> [!WARNING]
> you might need to reset your environment with ./clean.sh because postgres service can be **downgraded**

- set version for components to avoid an unwanted upgrade of postgres for instance
- force upgrade of tchap forked components : `tchap-web` and  `mas-tchap` by pulling new images at each restart


Bonus : 
- add ratelimiting for register and login