### PR TITLE
To be able to execute synapse local

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -52,5 +52,5 @@ KEYCLOAK_POSTGRES_PORT=5434
 SYNAPSE_POSTGRES_PORT=5435
 
 #choose which services to start with docker compose profiles.
-#availables : tchap, [with_tchap_mas|with_element_mas], [with_tchap_web|with_element_web], with_element_call, with_workers
-COMPOSE_PROFILES="tchap,with_tchap_mas,with_tchap_web"
+#availables : tchap, [with_tchap_mas|with_element_mas], [with_tchap_web|with_element_web],[with_element_synapse,with_local_synapse] with_element_call, with_workers
+COMPOSE_PROFILES="tchap,with_tchap_mas,with_tchap_web,with_element_synapse"

--- a/compose.yml
+++ b/compose.yml
@@ -170,6 +170,8 @@ services:
         condition: service_healthy
       init:
         condition: service_completed_successfully
+    profiles:
+      [with_element_synapse]
 
   synapse-generic-worker-1:
     image: ghcr.io/element-hq/synapse:v1.136.0

--- a/data-template/mas/config.yaml
+++ b/data-template/mas/config.yaml
@@ -217,6 +217,7 @@ tchap:
   # old email in mail.numerique.gouv.fr
   - match_with : '@numerique.gouv.fr'
     search: '@beta.gouv.fr'
+  tchap_app_link: 'https://element.tchapgouv.com'
 
 
 rate_limiting:

--- a/tchap/mas/config.local.dev.yaml
+++ b/tchap/mas/config.local.dev.yaml
@@ -217,6 +217,7 @@ tchap:
   # old email in mail.numerique.gouv.fr
   - match_with : '@numerique.gouv.fr'
     search: '@beta.gouv.fr'
+  tchap_app_link: 'https://element.tchapgouv.com'
 
 
 rate_limiting:

--- a/tchap/nginx/assemble-nginx-config.sh
+++ b/tchap/nginx/assemble-nginx-config.sh
@@ -18,6 +18,13 @@ if has_profile "with_tchap_mas"; then
     export MAS_SERVICE="http://host.docker.internal:8080"
 fi
 
+export SYNAPSE_SERVICE="http://synapse:8008"
+# Update service variables based on active profiles
+if has_profile "with_local_synapse"; then
+    echo "Using synapse-tchap service"
+    export SYNAPSE_SERVICE="http://host.docker.internal:8008"
+fi
+
 export APP_WEB_SERVICE="http://element-web"
 if has_profile "with_tchap_web"; then
     echo "Using tchap-web service"

--- a/tchap/nginx/full-profiles/base.conf.template
+++ b/tchap/nginx/full-profiles/base.conf.template
@@ -109,7 +109,8 @@ server {
     ${IDENTITY_SERVER_CONFIG}
 
     location / {
-        proxy_pass http://synapse:8008;
+        #proxy_pass http://synapse:8008;
+        proxy_pass ${SYNAPSE_SERVICE};
         proxy_set_header X-Forwarded-For ${DOLLAR}remote_addr;
         proxy_set_header X-Forwarded-Proto ${DOLLAR}scheme;
         proxy_set_header Host ${DOLLAR}host;


### PR DESCRIPTION
- `with_element_synapse` allow to execute docker element synapse : behaviour by default
- `with_local_synapse` allow to execute local synapse as described [here](https://github.com/element-hq/synapse/blob/develop/docs/development/contributing_guide.md): https://github.com/tchapgouv/synapse/pull/3
- update mas/config : tchap_app_link 